### PR TITLE
feat(deputynode): add abnormal block minerAddress

### DIFF
--- a/chain/deputynode/manager.go
+++ b/chain/deputynode/manager.go
@@ -27,7 +27,7 @@ type Manager struct {
 	termList []*TermRecord
 	lock     sync.Mutex
 
-	evilDeputies map[string]uint32
+	evilDeputies map[string]uint32 // key is nodeId, value is cut-off height
 	edLock       sync.Mutex
 }
 
@@ -54,7 +54,7 @@ func (m *Manager) IsEvilDeputyNode(nodeId string, currentHeight uint32) bool {
 	return false
 }
 
-// SetAbnormalDeputyNode
+// SetAbnormalDeputyNode height is cut-off height
 func (m *Manager) PutEvilDeputyNode(nodeId string, height uint32) {
 	m.edLock.Lock()
 	defer m.edLock.Unlock()

--- a/chain/deputynode/manager.go
+++ b/chain/deputynode/manager.go
@@ -27,7 +27,7 @@ type Manager struct {
 	termList []*TermRecord
 	lock     sync.Mutex
 
-	evilDeputies map[string]uint32 // key is nodeId, value is cut-off height
+	evilDeputies map[common.Address]uint32 // key is minerAddress, value is release height
 	edLock       sync.Mutex
 }
 
@@ -36,17 +36,17 @@ func NewManager(deputyCount int) *Manager {
 	return &Manager{
 		DeputyCount:  deputyCount,
 		termList:     make([]*TermRecord, 0),
-		evilDeputies: make(map[string]uint32),
+		evilDeputies: make(map[common.Address]uint32),
 	}
 }
 
-// IsEvilDeputyNode
-func (m *Manager) IsEvilDeputyNode(nodeId string, currentHeight uint32) bool {
+// IsEvilDeputyNode currentHeight is current block height
+func (m *Manager) IsEvilDeputyNode(minerAddress common.Address, currentHeight uint32) bool {
 	m.edLock.Lock()
 	defer m.edLock.Unlock()
-	if height, exit := m.evilDeputies[nodeId]; exit {
+	if height, exit := m.evilDeputies[minerAddress]; exit {
 		if currentHeight >= height {
-			delete(m.evilDeputies, nodeId)
+			delete(m.evilDeputies, minerAddress)
 			return false
 		}
 		return true
@@ -54,11 +54,11 @@ func (m *Manager) IsEvilDeputyNode(nodeId string, currentHeight uint32) bool {
 	return false
 }
 
-// SetAbnormalDeputyNode height is cut-off height
-func (m *Manager) PutEvilDeputyNode(nodeId string, height uint32) {
+// SetAbnormalDeputyNode height is release height
+func (m *Manager) PutEvilDeputyNode(minerAddress common.Address, height uint32) {
 	m.edLock.Lock()
 	defer m.edLock.Unlock()
-	m.evilDeputies[nodeId] = height
+	m.evilDeputies[minerAddress] = height
 }
 
 // SaveSnapshot add deputy nodes record by snapshot block data

--- a/chain/deputynode/manager.go
+++ b/chain/deputynode/manager.go
@@ -24,16 +24,42 @@ var (
 type Manager struct {
 	DeputyCount int // Max deputy count. Not include candidate nodes
 
-	termList []*TermRecord
-	lock     sync.Mutex
+	termList           []*TermRecord
+	abnormalDeputyNode map[string]struct{}
+	lock               sync.Mutex
 }
 
 // NewManager creates a new Manager. It is used to maintain term record list
 func NewManager(deputyCount int) *Manager {
 	return &Manager{
-		DeputyCount: deputyCount,
-		termList:    make([]*TermRecord, 0),
+		DeputyCount:        deputyCount,
+		termList:           make([]*TermRecord, 0),
+		abnormalDeputyNode: make(map[string]struct{}),
 	}
+}
+
+// IsAbnormalDeputyNode
+func (m *Manager) IsAbnormalDeputyNode(minerAddress string) bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if _, exit := m.abnormalDeputyNode[minerAddress]; exit {
+		return true
+	}
+	return false
+}
+
+// SetAbnormalDeputyNode
+func (m *Manager) PutAbnormalDeputyNode(minerAddress string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.abnormalDeputyNode[minerAddress] = struct{}{}
+}
+
+// DeleteAbnormalDeputyNode
+func (m *Manager) DeleteAbnormalDeputyNode(minerAddress string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	delete(m.abnormalDeputyNode, minerAddress)
 }
 
 // SaveSnapshot add deputy nodes record by snapshot block data

--- a/chain/deputynode/manager.go
+++ b/chain/deputynode/manager.go
@@ -41,12 +41,12 @@ func NewManager(deputyCount int) *Manager {
 }
 
 // IsEvilDeputyNode
-func (m *Manager) IsEvilDeputyNode(minerAddress string, currentHeight uint32) bool {
+func (m *Manager) IsEvilDeputyNode(nodeId string, currentHeight uint32) bool {
 	m.edLock.Lock()
 	defer m.edLock.Unlock()
-	if height, exit := m.evilDeputies[minerAddress]; exit {
+	if height, exit := m.evilDeputies[nodeId]; exit {
 		if currentHeight >= height {
-			delete(m.evilDeputies, minerAddress)
+			delete(m.evilDeputies, nodeId)
 			return false
 		}
 		return true
@@ -55,10 +55,10 @@ func (m *Manager) IsEvilDeputyNode(minerAddress string, currentHeight uint32) bo
 }
 
 // SetAbnormalDeputyNode
-func (m *Manager) PutEvilDeputyNode(minerAddress string, height uint32) {
+func (m *Manager) PutEvilDeputyNode(nodeId string, height uint32) {
 	m.edLock.Lock()
 	defer m.edLock.Unlock()
-	m.evilDeputies[minerAddress] = height
+	m.evilDeputies[nodeId] = height
 }
 
 // SaveSnapshot add deputy nodes record by snapshot block data


### PR DESCRIPTION
1. 在deputynode_manager中增加一个map来存储同一高度接收到两个相同minerAddress的区块，其中map的key为区块的minerAddress.String(),不是nodeID的原因是minerAddress和nodeID是一一对应的，我们收到的区块想要获取出块者的nodeID也是通过区块的minerAddress去获取的，所以这里就直接存储区块的minerAddress就行。
2. 新增了三个方法，对此map的查询、增加、删除操作。