### PR TITLE
fix(subscribe): fix unSub ch

### DIFF
--- a/common/subscribe/route.go
+++ b/common/subscribe/route.go
@@ -123,7 +123,7 @@ func (r *CentralRouteSub) unSub(name string, ch interface{}) error {
 	}
 
 	cases := r.names[name].caseList
-	if chType != reflect.TypeOf(cases[0]) {
+	if chType != cases[0].Chan.Type() {
 		return ErrChType
 	}
 


### PR DESCRIPTION
解正常退出glemo程序的时候打印出"error of channel type"的问题