### PR TITLE
feat(consensus): add fetch confirm delay 30s function

### DIFF
--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -101,7 +101,7 @@ func (bc *BlockChain) runFeedTranspondLoop() {
 	stableSub := bc.engine.SubscribeStable(stableCh)
 	confirmCh := make(chan *network.BlockConfirmData)
 	confirmSub := bc.engine.SubscribeConfirm(confirmCh)
-	fetchConfirmCh := make(chan *[]network.GetConfirmInfo)
+	fetchConfirmCh := make(chan []network.GetConfirmInfo)
 	fetchConfirmSub := bc.engine.SubscribeFetchConfirm(fetchConfirmCh)
 	for {
 		select {

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -101,15 +101,20 @@ func (bc *BlockChain) runFeedTranspondLoop() {
 	stableSub := bc.engine.SubscribeStable(stableCh)
 	confirmCh := make(chan *network.BlockConfirmData)
 	confirmSub := bc.engine.SubscribeConfirm(confirmCh)
+	fetchConfirmCh := make(chan *[]network.GetConfirmInfo)
+	fetchConfirmSub := bc.engine.SubscribeFetchConfirm(fetchConfirmCh)
 	for {
 		select {
 		case block := <-stableCh:
 			go subscribe.Send(subscribe.NewStableBlock, block)
 		case confirm := <-confirmCh:
 			go subscribe.Send(subscribe.NewConfirm, confirm)
+		case confirmsInfo := <-fetchConfirmCh:
+			go subscribe.Send(subscribe.FetchConfirms, confirmsInfo)
 		case <-bc.quitCh:
 			stableSub.Unsubscribe()
 			confirmSub.Unsubscribe()
+			fetchConfirmSub.Unsubscribe()
 			return
 		}
 	}

--- a/chain/consensus/confirmer.go
+++ b/chain/consensus/confirmer.go
@@ -111,7 +111,7 @@ func (c *Confirmer) BatchConfirmStable(startHeight, endHeight uint32) []*network
 }
 
 // NeedFetchedConfirms
-func (c *Confirmer) NeedFetchedConfirms(startHeight, endHeight uint32) *[]network.GetConfirmInfo {
+func (c *Confirmer) NeedFetchedConfirms(startHeight, endHeight uint32) []network.GetConfirmInfo {
 	if startHeight > endHeight {
 		return nil
 	}
@@ -131,7 +131,7 @@ func (c *Confirmer) NeedFetchedConfirms(startHeight, endHeight uint32) *[]networ
 		}
 		confirms = append(confirms, info)
 	}
-	return &confirms
+	return confirms
 }
 
 // SetLastSig

--- a/chain/consensus/dpovp.go
+++ b/chain/consensus/dpovp.go
@@ -84,7 +84,7 @@ func (dp *DPoVP) SubscribeConfirm(ch chan *network.BlockConfirmData) subscribe.S
 }
 
 // SubscribeFetchConfirm subscribe fetch block confirms
-func (dp *DPoVP) SubscribeFetchConfirm(ch chan *[]network.GetConfirmInfo) subscribe.Subscription {
+func (dp *DPoVP) SubscribeFetchConfirm(ch chan []network.GetConfirmInfo) subscribe.Subscription {
 	return dp.fetchConfirmsFeed.Subscribe(ch)
 }
 
@@ -213,12 +213,12 @@ func (dp *DPoVP) broadcastConfirm(block *types.Block, sig types.SignData) {
 	dp.confirmFeed.Send(pack)
 }
 
-// fetchConfirmsFromRemote after 30s fetch confirm from remote peer
+// fetchConfirmsFromRemote fetch confirms from remote peer after 30s
 func (dp *DPoVP) fetchConfirmsFromRemote(startHeight, endHeight uint32) {
 	// time.AfterFunc its own goroutine
 	time.AfterFunc(delayFetchConfirmsTime, func() {
 		info := dp.confirmer.NeedFetchedConfirms(startHeight, endHeight)
-		if info == nil || len(*info) == 0 {
+		if info == nil || len(info) == 0 {
 			return
 		}
 		dp.fetchConfirmsFeed.Send(info)

--- a/common/subscribe/route.go
+++ b/common/subscribe/route.go
@@ -15,6 +15,7 @@ const (
 	NewStableBlock = "newStableBlock"
 	NewTx          = "newTx"
 	NewConfirm     = "newConfirm"
+	FetchConfirms  = "fetchConfirm"
 )
 
 var (

--- a/network/peer.go
+++ b/network/peer.go
@@ -152,80 +152,80 @@ func (p *peer) ReadMsg() (*p2p.Msg, error) {
 }
 
 // SendLstStatus send SyncFailednode's status to remote
-func (p *peer) SendLstStatus(status *LatestStatus) int {
+func (p *peer) SendLstStatus(status *LatestStatus) error {
 	buf, err := rlp.EncodeToBytes(status)
 	if err != nil {
 		log.Warnf("SendLstStatus: rlp encode failed: %v", err)
-		return -1
+		return err
 	}
 	p.conn.SetWriteDeadline(DurShort)
 	if err = p.conn.WriteMsg(LstStatusMsg, buf); err != nil {
 		log.Warnf("SendLstStatus to peer: %s failed: %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendTxs send txs to remote
-func (p *peer) SendTxs(txs types.Transactions) int {
+func (p *peer) SendTxs(txs types.Transactions) error {
 	buf, err := rlp.EncodeToBytes(&txs)
 	if err != nil {
 		log.Warnf("SendTxs: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	if err := p.conn.WriteMsg(TxsMsg, buf); err != nil {
 		log.Warnf("SendTxs to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendConfirmInfo send confirm message to deputy nodes
-func (p *peer) SendConfirmInfo(confirmInfo *BlockConfirmData) int {
+func (p *peer) SendConfirmInfo(confirmInfo *BlockConfirmData) error {
 	buf, err := rlp.EncodeToBytes(confirmInfo)
 	if err != nil {
 		log.Warnf("SendConfirmInfo: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	p.conn.SetWriteDeadline(DurShort)
 	if err := p.conn.WriteMsg(ConfirmMsg, buf); err != nil {
 		log.Warnf("SendConfirmInfo to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendBlockHash send block hash to remote
-func (p *peer) SendBlockHash(height uint32, hash common.Hash) int {
+func (p *peer) SendBlockHash(height uint32, hash common.Hash) error {
 	msg := &BlockHashData{Height: height, Hash: hash}
 	buf, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		log.Warnf("SendBlockHash: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	p.conn.SetWriteDeadline(DurShort)
 	if err := p.conn.WriteMsg(BlockHashMsg, buf); err != nil {
 		log.Warnf("SendBlockHash: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendBlocks send blocks to remote
-func (p *peer) SendBlocks(blocks types.Blocks) int {
+func (p *peer) SendBlocks(blocks types.Blocks) error {
 	buf, err := rlp.EncodeToBytes(&blocks)
 	if err != nil {
 		log.Warnf("SendBlocks: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	if err := p.conn.WriteMsg(BlocksMsg, buf); err != nil {
 		// log.Warnf("SendBlocks to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
 	// for test
 	// block := blocks[0]
@@ -239,90 +239,90 @@ func (p *peer) SendBlocks(blocks types.Blocks) int {
 	// 		}
 	// 	}
 	// }
-	return 0
+	return nil
 }
 
 // SendConfirms send confirms to remote peer
-func (p *peer) SendConfirms(confirms *BlockConfirms) int {
+func (p *peer) SendConfirms(confirms *BlockConfirms) error {
 	buf, err := rlp.EncodeToBytes(confirms)
 	if err != nil {
 		log.Warnf("SendConfirms: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	p.conn.SetWriteDeadline(DurLong)
 	if err := p.conn.WriteMsg(ConfirmsMsg, buf); err != nil {
 		log.Warnf("SendConfirms to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendGetConfirms send request of getting confirms
-func (p *peer) SendGetConfirms(height uint32, hash common.Hash) int {
+func (p *peer) SendGetConfirms(height uint32, hash common.Hash) error {
 	msg := &GetConfirmInfo{Height: height, Hash: hash}
 	buf, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		log.Warnf("SendGetConfirms: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	p.conn.SetWriteDeadline(DurShort)
 	if err := p.conn.WriteMsg(GetConfirmsMsg, buf); err != nil {
 		log.Warnf("SendGetConfirms to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendDiscover send discover request
-func (p *peer) SendDiscover() int {
+func (p *peer) SendDiscover() error {
 	msg := &DiscoverReqData{Sequence: 1}
 	buf, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		log.Warnf("SendDiscover: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	p.discoverCounter++
 	p.conn.SetWriteDeadline(DurShort)
 	if err := p.conn.WriteMsg(DiscoverReqMsg, buf); err != nil {
 		log.Warnf("SendDiscover to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendDiscoverResp send response for discover
-func (p *peer) SendDiscoverResp(resp *DiscoverResData) int {
+func (p *peer) SendDiscoverResp(resp *DiscoverResData) error {
 	buf, err := rlp.EncodeToBytes(resp)
 	if err != nil {
 		log.Warnf("SendDiscoverResp: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	if err := p.conn.WriteMsg(DiscoverResMsg, buf); err != nil {
 		log.Warnf("SendDiscoverResp to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // SendReqLatestStatus send request of latest status
-func (p *peer) SendReqLatestStatus() int {
+func (p *peer) SendReqLatestStatus() error {
 	msg := &GetLatestStatus{Revert: uint32(0)}
 	buf, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		log.Warnf("SendReqLatestStatus: rlp failed: %v", err)
-		return -1
+		return err
 	}
 	p.conn.SetWriteDeadline(DurShort)
 	if err := p.conn.WriteMsg(GetLstStatusMsg, buf); err != nil {
 		log.Warnf("SendReqLatestStatus to peer: %s failed. disconnect. %v", p.NodeID().String()[:16], err)
 		p.conn.Close()
-		return -2
+		return err
 	}
-	return 0
+	return nil
 }
 
 // LatestStatus return record of latest status

--- a/network/protocol_manager.go
+++ b/network/protocol_manager.go
@@ -194,8 +194,8 @@ func (pm *ProtocolManager) txConfirmLoop() {
 			peers := pm.peers.DeputyNodes(curHeight)
 			go pm.broadcastConfirm(peers, info)
 			log.Debugf("broadcast confirm, len(peers)=%d, height: %d", len(peers), info.Height)
-		case infoes := <-pm.fetchConfirms:
-			go pm.fetchConfirmFromRemote(infoes)
+		case infoList := <-pm.fetchConfirms:
+			go pm.fetchConfirmFromRemote(infoList)
 		}
 	}
 }
@@ -337,8 +337,8 @@ func (pm *ProtocolManager) stableBlockLoop() {
 }
 
 // fetchConfirmFromRemote
-func (pm *ProtocolManager) fetchConfirmFromRemote(infoes []GetConfirmInfo) {
-	length := len(infoes)
+func (pm *ProtocolManager) fetchConfirmFromRemote(infoList []GetConfirmInfo) {
+	length := len(infoList)
 	if length == 0 {
 		return
 	}
@@ -346,8 +346,8 @@ func (pm *ProtocolManager) fetchConfirmFromRemote(infoes []GetConfirmInfo) {
 	// get maximal height for find the best peer
 	var maxHeight uint32 = 0
 	for i := 0; i < length; i++ {
-		if infoes[i].Height > maxHeight {
-			maxHeight = infoes[i].Height
+		if infoList[i].Height > maxHeight {
+			maxHeight = infoList[i].Height
 		}
 	}
 	// find the best peer to fetch block confirms
@@ -357,7 +357,7 @@ func (pm *ProtocolManager) fetchConfirmFromRemote(infoes []GetConfirmInfo) {
 	}
 
 	for i := 0; i < length; i++ {
-		err := p.SendGetConfirms(infoes[i].Height, infoes[i].Hash)
+		err := p.SendGetConfirms(infoList[i].Height, infoList[i].Hash)
 		if err != nil {
 			log.Errorf("Send get confirms message error,errorCode = %d", err)
 			return


### PR DESCRIPTION
在consensus中添加延时拉取稳定块的父块的确认包，并移除在network中收到稳定块后再去请求父块的确认包的逻辑