### PR TITLE
New readonly account

### DIFF
--- a/chain/account/manager.go
+++ b/chain/account/manager.go
@@ -95,13 +95,6 @@ func (am *Manager) getRawAccount(address common.Address) *Account {
 	return safeAccount.(*SafeAccount).rawAccount
 }
 
-// IsExist reports whether the given account address exists in the db.
-// Notably this also returns true for suicided accounts.
-func (am *Manager) IsExist(address common.Address) bool {
-	data, _ := am.acctDb.Get(address)
-	return data != nil
-}
-
 // AddEvent records the event during transaction's execution.
 func (am *Manager) AddEvent(event *types.Event) {
 	if (event.Address == common.Address{}) {

--- a/chain/account/manager_readonly.go
+++ b/chain/account/manager_readonly.go
@@ -62,6 +62,16 @@ func (am *ReadOnlyManager) Reset(blockHash common.Hash) {
 	am.accountCache = make(map[common.Address]*ReadOnlyAccount)
 }
 
+// GetStableAccount return stable account from db
+func (am *ReadOnlyManager) GetStableAccount(address common.Address) types.AccountAccessor {
+	data, err := am.db.GetAccount(address)
+	if err != nil && err != store.ErrNotExist {
+		panic(err)
+	}
+	return NewReadOnlyAccount(am.db, address, data)
+}
+
+// GetAccount return the latest account
 func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
 	cached := am.accountCache[address]
 	if cached == nil {

--- a/chain/account/manager_readonly.go
+++ b/chain/account/manager_readonly.go
@@ -63,7 +63,7 @@ func (am *ReadOnlyManager) Reset(blockHash common.Hash) {
 }
 
 // GetStableAccount return stable account from db
-func (am *ReadOnlyManager) GetStableAccount(address common.Address) types.AccountAccessor {
+func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
 	data, err := am.db.GetAccount(address)
 	if err != nil && err != store.ErrNotExist {
 		panic(err)
@@ -72,7 +72,7 @@ func (am *ReadOnlyManager) GetStableAccount(address common.Address) types.Accoun
 }
 
 // GetAccount return the latest account
-func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
+func (am *ReadOnlyManager) GetLatestAccount(address common.Address) types.AccountAccessor {
 	cached := am.accountCache[address]
 	if cached == nil {
 		var data *types.AccountData

--- a/chain/account/manager_readonly.go
+++ b/chain/account/manager_readonly.go
@@ -63,7 +63,7 @@ func (am *ReadOnlyManager) Reset(blockHash common.Hash) {
 }
 
 // GetStableAccount return stable account from db
-func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
+func (am *ReadOnlyManager) GetLatestAccount(address common.Address) types.AccountAccessor {
 	data, err := am.db.GetAccount(address)
 	if err != nil && err != store.ErrNotExist {
 		panic(err)
@@ -72,7 +72,7 @@ func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAcces
 }
 
 // GetAccount return the latest account
-func (am *ReadOnlyManager) GetLatestAccount(address common.Address) types.AccountAccessor {
+func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
 	cached := am.accountCache[address]
 	if cached == nil {
 		var data *types.AccountData

--- a/chain/account/manager_readonly.go
+++ b/chain/account/manager_readonly.go
@@ -64,11 +64,16 @@ func (am *ReadOnlyManager) Reset(blockHash common.Hash) {
 	am.accountCache = make(map[common.Address]*ReadOnlyAccount)
 }
 
-// getAccount return stable account from db
-func (am *ReadOnlyManager) getAccount(address common.Address, stableOnly bool) types.AccountAccessor {
+// GetAccount
+func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
+	// 从缓存中读取account
+	if cached, ok := am.accountCache[address]; ok {
+		return cached
+	}
+
 	var data *types.AccountData
 	var err error
-	if stableOnly || am.acctDb == nil {
+	if am.stableOnly || am.acctDb == nil {
 		data, err = am.db.GetAccount(address)
 	} else {
 		data, err = am.acctDb.Get(address)
@@ -81,16 +86,6 @@ func (am *ReadOnlyManager) getAccount(address common.Address, stableOnly bool) t
 	// cache it
 	am.accountCache[address] = account
 	return account
-}
-
-// GetAccount
-func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
-	// 从缓存中读取account
-	if cached, ok := am.accountCache[address]; ok {
-		return cached
-	}
-
-	return am.getAccount(address, am.stableOnly)
 }
 
 func (am *ReadOnlyManager) RevertToSnapshot(int) {

--- a/chain/account/manager_readonly.go
+++ b/chain/account/manager_readonly.go
@@ -1,20 +1,94 @@
 package account
 
 import (
+	"errors"
+	"github.com/LemoFoundationLtd/lemochain-core/chain/types"
 	"github.com/LemoFoundationLtd/lemochain-core/common"
+	"github.com/LemoFoundationLtd/lemochain-core/common/log"
+	"github.com/LemoFoundationLtd/lemochain-core/store"
 	"github.com/LemoFoundationLtd/lemochain-core/store/protocol"
 )
 
-// ReadOnlyManager
-func ReadOnlyManager(blockHash common.Hash, db protocol.ChainDB) *Manager {
-	manager := &Manager{
-		db:            db,
-		baseBlockHash: blockHash,
+var (
+	ErrSaveReadOnly = errors.New("can not save a read only account")
+)
+
+// ReadOnlyAccount is used to block any save action on Account
+type ReadOnlyAccount struct {
+	Account
+}
+
+func NewReadOnlyAccount(db protocol.ChainDB, address common.Address, data *types.AccountData) *ReadOnlyAccount {
+	return &ReadOnlyAccount{Account: *NewAccount(db, address, data)}
+}
+
+func (a *ReadOnlyAccount) Finalise() error {
+	return ErrSaveReadOnly
+}
+
+func (a *ReadOnlyAccount) Save() error {
+	return ErrSaveReadOnly
+}
+
+// ReadOnlyManager is used to access the newest readonly account data
+type ReadOnlyManager struct {
+	db           protocol.ChainDB
+	acctDb       *store.AccountTrieDB
+	accountCache map[common.Address]*ReadOnlyAccount
+}
+
+// NewManager creates a new Manager. It is used to maintain account changes based on the block environment which specified by blockHash
+func NewReadOnlyManager(db protocol.ChainDB) *ReadOnlyManager {
+	if db == nil {
+		panic("account.NewManager is called without a database")
 	}
-	manager.loadBaseBlock()
-	manager.acctDb, _ = db.GetActDatabase(blockHash)
-	manager.processor = &LogProcessor{
-		accountLoader: manager,
+	manager := &ReadOnlyManager{
+		db:           db,
+		accountCache: make(map[common.Address]*ReadOnlyAccount),
 	}
+
 	return manager
+}
+
+// Reset clears out all data and switch state to the new block environment. It is not necessary to reset if only use stable accounts data
+func (am *ReadOnlyManager) Reset(blockHash common.Hash) {
+	exist, err := am.db.IsExistByHash(blockHash)
+	if err != nil || !exist {
+		log.Errorf("Reset ReadOnlyManager to block[%#x] fail: %s", blockHash, err)
+		return
+	}
+
+	am.acctDb, _ = am.db.GetActDatabase(blockHash)
+	am.accountCache = make(map[common.Address]*ReadOnlyAccount)
+}
+
+func (am *ReadOnlyManager) GetAccount(address common.Address) types.AccountAccessor {
+	cached := am.accountCache[address]
+	if cached == nil {
+		var data *types.AccountData
+		var err error
+		// If acctDB is exist, then we use the newest unstable account, otherwise the newest stable account
+		if am.acctDb != nil {
+			data, err = am.acctDb.Get(address)
+		} else {
+			data, err = am.db.GetAccount(address)
+		}
+		if err != nil && err != store.ErrNotExist {
+			log.Error("Load read only account fail", "err", err)
+		}
+		account := NewReadOnlyAccount(am.db, address, data)
+		// cache it
+		am.accountCache[address] = account
+	}
+	return cached
+}
+
+func (am *ReadOnlyManager) RevertToSnapshot(int) {
+}
+
+func (am *ReadOnlyManager) Snapshot() int {
+	return 0
+}
+
+func (am *ReadOnlyManager) AddEvent(*types.Event) {
 }

--- a/chain/account/safe_account_test.go
+++ b/chain/account/safe_account_test.go
@@ -21,7 +21,7 @@ func loadSafeAccount(address common.Address) *SafeAccount {
 	return NewSafeAccount(NewManager(newestBlock.Hash(), db).processor, NewAccount(db, address, data))
 }
 
-func TestSafeAccount_SetBalance_IsDirty(t *testing.T) {
+func TestSafeAccount_SetBalance(t *testing.T) {
 	account := loadSafeAccount(defaultAccounts[0].Address)
 	defer account.rawAccount.db.Close()
 
@@ -32,7 +32,7 @@ func TestSafeAccount_SetBalance_IsDirty(t *testing.T) {
 	assert.Equal(t, *big.NewInt(200), account.processor.changeLogs[0].NewVal.(big.Int))
 }
 
-func TestSafeAccount_SetCode_IsDirty(t *testing.T) {
+func TestSafeAccount_SetCode(t *testing.T) {
 	account := loadSafeAccount(defaultAccounts[0].Address)
 	defer account.rawAccount.db.Close()
 
@@ -42,7 +42,7 @@ func TestSafeAccount_SetCode_IsDirty(t *testing.T) {
 	assert.Equal(t, types.Code{0x12}, account.processor.changeLogs[0].NewVal.(types.Code))
 }
 
-func TestSafeAccount_SetStorageState_IsDirty(t *testing.T) {
+func TestSafeAccount_SetStorageState(t *testing.T) {
 	account := loadSafeAccount(defaultAccounts[0].Address)
 	defer account.rawAccount.db.Close()
 

--- a/chain/transaction/tx_processor.go
+++ b/chain/transaction/tx_processor.go
@@ -578,7 +578,7 @@ func newTx(to *common.Address, txType uint16, data []byte, chainID uint16) (*typ
 }
 
 // getEVM
-func getEVM(tx *types.Transaction, header *types.Header, txIndex uint, txHash common.Hash, blockHash common.Hash, chain BlockLoader, cfg vm.Config, accM *account.Manager) *vm.EVM {
+func getEVM(tx *types.Transaction, header *types.Header, txIndex uint, txHash common.Hash, blockHash common.Hash, chain BlockLoader, cfg vm.Config, accM vm.AccountManager) *vm.EVM {
 	evmContext := NewEVMContext(tx, header, txIndex, blockHash, chain)
 	vmEnv := vm.NewEVM(evmContext, accM, cfg)
 	return vmEnv

--- a/chain/transaction/tx_processor.go
+++ b/chain/transaction/tx_processor.go
@@ -457,11 +457,10 @@ func (p *TxProcessor) chargeForGas(charge *big.Int, minerAddress common.Address)
 }
 
 // PreExecutionTransaction pre-execute transactions and contracts.
-func (p *TxProcessor) PreExecutionTransaction(ctx context.Context, header *types.Header, to *common.Address, txType uint16, data hexutil.Bytes, blockHash common.Hash, timeout time.Duration) ([]byte, uint64, error) {
+func (p *TxProcessor) PreExecutionTransaction(ctx context.Context, accM *account.ReadOnlyManager, header *types.Header, to *common.Address, txType uint16, data hexutil.Bytes, blockHash common.Hash, timeout time.Duration) ([]byte, uint64, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	accM := account.NewReadOnlyManager(p.db)
 	accM.Reset(header.Hash())
 
 	// A random address is found as our caller address.

--- a/chain/transaction/tx_processor.go
+++ b/chain/transaction/tx_processor.go
@@ -461,8 +461,8 @@ func (p *TxProcessor) PreExecutionTransaction(ctx context.Context, header *types
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	accM := account.ReadOnlyManager(header.Hash(), p.db)
-	accM.Reset(header.ParentHash)
+	accM := account.NewReadOnlyManager(p.db)
+	accM.Reset(header.Hash())
 
 	// A random address is found as our caller address.
 	strAddress := "0x20190306" // todo Consider letting users pass in their own addresses

--- a/chain/vm/interface.go
+++ b/chain/vm/interface.go
@@ -10,7 +10,6 @@ import (
 // AccountManager is an EVM database for full account querying.
 type AccountManager interface {
 	GetAccount(common.Address) types.AccountAccessor
-	IsExist(common.Address) bool
 
 	RevertToSnapshot(int)
 	Snapshot() int

--- a/main/node/api.go
+++ b/main/node/api.go
@@ -455,7 +455,8 @@ func (t *PublicTxAPI) PendingTx(size int) []*types.Transaction {
 // ReadContract read variables in a contract includes the return value of a function.
 func (t *PublicTxAPI) ReadContract(to *common.Address, data hexutil.Bytes) (string, error) {
 	ctx := context.Background()
-	result, _, err := t.doCallTransaction(ctx, to, params.OrdinaryTx, data, 5*time.Second)
+	accM := account.NewReadOnlyManager(t.node.Db(), true)
+	result, _, err := t.doCallTransaction(ctx, to, accM, params.OrdinaryTx, data, 5*time.Second)
 	return common.ToHex(result), err
 }
 
@@ -464,7 +465,8 @@ func (t *PublicTxAPI) EstimateGas(to *common.Address, txType uint16, data hexuti
 	var costGas uint64
 	var err error
 	ctx := context.Background()
-	_, costGas, err = t.doCallTransaction(ctx, to, txType, data, 5*time.Second)
+	accM := account.NewReadOnlyManager(t.node.Db(), false)
+	_, costGas, err = t.doCallTransaction(ctx, to, accM, txType, data, 5*time.Second)
 	strCostGas := strconv.FormatUint(costGas, 10)
 	return strCostGas, err
 }
@@ -473,23 +475,23 @@ func (t *PublicTxAPI) EstimateGas(to *common.Address, txType uint16, data hexuti
 // Todo will delete
 func (t *PublicTxAPI) EstimateCreateContractGas(data hexutil.Bytes) (uint64, error) {
 	ctx := context.Background()
-	_, costGas, err := t.doCallTransaction(ctx, nil, params.OrdinaryTx, data, 5*time.Second)
+	accM := account.NewReadOnlyManager(t.node.Db(), false)
+	_, costGas, err := t.doCallTransaction(ctx, nil, accM, params.OrdinaryTx, data, 5*time.Second)
 	return costGas, err
 }
 
 // doCallTransaction
-func (t *PublicTxAPI) doCallTransaction(ctx context.Context, to *common.Address, txType uint16, data hexutil.Bytes, timeout time.Duration) ([]byte, uint64, error) {
+func (t *PublicTxAPI) doCallTransaction(ctx context.Context, to *common.Address, accM *account.ReadOnlyManager, txType uint16, data hexutil.Bytes, timeout time.Duration) ([]byte, uint64, error) {
 	t.node.lock.Lock()
 	defer t.node.lock.Unlock()
 
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
-	// get latest stableBlock
-	stableBlock := t.node.chain.StableBlock()
-	log.Infof("Stable block height = %v", stableBlock.Height())
-	stableHeader := stableBlock.Header
-
+	// get current stableBlock
+	currentBlock := t.node.chain.CurrentBlock()
+	log.Infof("Current block height = %v", currentBlock.Height())
+	currentHeader := currentBlock.Header
 	p := t.node.chain.TxProcessor()
-	ret, costGas, err := p.PreExecutionTransaction(ctx, stableHeader, to, txType, data, common.Hash{}, timeout)
+	ret, costGas, err := p.PreExecutionTransaction(ctx, accM, currentHeader, to, txType, data, common.Hash{}, timeout)
 
 	return ret, costGas, err
 }


### PR DESCRIPTION
重构read_only_account_manager，增加从稳定块中读取account和从最新块中读取数据。
主要用于预估交易gas和读取合约。